### PR TITLE
Support parsing files with trailing whitespace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
 	"version": "1.0.4",
 	"author": "raravel",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/raravel/git-submodule-js.git"
+	},
+	"homepage": "https://github.com/raravel/git-submodule-js",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function deserialize(str: string): Submodule {
 			let subline = ss[++idx];
 			while ( subline && subline.trim() ) {
 				subline = ss[idx];
-				if ( !subline || subline.match(/\[submodule\s+\"(.*?)\"\]/) ) {
+				if ( !subline.trim() || subline.match(/\[submodule\s+\"(.*?)\"\]/) ) {
 					idx--;
 					break;
 				}


### PR DESCRIPTION
Trailing whitespace on empty lines causes the parser to break:

<img width="1040" alt="Screenshot 2024-11-27 at 23 58 55" src="https://github.com/user-attachments/assets/71068a13-4e68-4a2a-977a-6b4582ee0a0e">

with: 
```
/Users/peter/zcode/extensions/node_modules/git-submodule-js/dist/index.js:24
                const [subginal, key, value] = subline.match(/(.*?)\s*=\s*(.*)/);
                                               ^

TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.deserialize (/Users/peter/zcode/extensions/node_modules/git-submodule-js/dist/index.js:24:48)
    at readGitmodules (file:///Users/peter/zcode/extensions/src/lib/git.js:41:24)
    at async sortGitmodules (file:///Users/peter/zcode/extensions/src/lib/git.js:46:22)
    at async file:///Users/peter/zcode/extensions/src/sort-extensions.js:5:1
```